### PR TITLE
[CORE-139] Add default DRCODEOWNERS file

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -1,0 +1,4 @@
+# Automatically created by set_owners.py by @alamb
+
+# entire repository is owned by Core Modeling
+/ @datarobot/core-modeling


### PR DESCRIPTION
Add default CODEOWNERS file. FYI @datarobot/core-modeling