### PR TITLE
Update pyyaml to address security vulnerability

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,6 @@ tox==2.3.1
 coverage==4.1
 Sphinx==1.4.8
 cryptography==1.7
-PyYAML==3.11
+PyYAML==4.2b1
 pytest==2.9.2
 pytest-runner==2.11.1


### PR DESCRIPTION
Apparently, pyyaml<4.2b1 has a security vulnerability. This PR bumps the version of pyyaml to address this concern.