### PR TITLE
Update Pillow and add 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+
+# Enable 3.7 without globally enabling sudo and xenial dist for other build jobs
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 =======
 History
 =======
-0.200.0 (2019-3-24)
+0.100.1 (2019-3-24)
 ------------------
 * Updated version of Pillow to 5.4.1, in order to support Python 3.7
 * Updated the README

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+0.200.0 (2019-3-24)
+------------------
+* Updated version of Pillow to 5.4.1, in order to support Python 3.7
+* Updated the README
+
 0.100.0 (2018-12-10)
 ------------------
 * Added test coverage and increased error checking

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Featurize images using a small, contained pre-trained deep learning network
 Features
 --------
 
-This is the prototype for image features engineering. Supports Python 2.7, 3.4, 3.5, and 3.6.
+This is the prototype for image features engineering. Supports Python 2.7, 3.4, 3.5, 3.6, and 3.7
 
 ``pic2vec`` is a python package that performs automated feature extraction
-for image data. It supports training models via the
-DataRobot modeling API, as well as feature engineering on new image data.
+for image data. It supports feature engineering on new image data, and allows
+traditional machine learning algorithms (such as tree-based algorithms) to
+train on image data.
+
 
 ## Input Specification
 
@@ -67,8 +69,7 @@ To get started, see the following example:
 1. [Cats vs. Dogs](examples/Cats_v_Dogs_Test_Example.ipynb): Dataset from combined directory + CSV
 
 Examples coming soon:
-1. [Facebook Like Prediction](examples/Facebook_Like_Predictor.ipynb): Dataset from unsupervised directory only, with PCA visualization
-1. [URLs](examples/): Dataset from CSV with URLs and no image directory
+2. Hot Dog, Not Hot Dog: Dataset from a CSV with URLs and no image directory
 
 
 ## Installation
@@ -80,7 +81,9 @@ If you run into trouble installing Keras or Tensorflow as a dependency, read the
 
 
 ## Using Featurizer Output With DataRobot
-``pic2vec`` generates a CSV that is ready to be dropped directly into the DataRobot application, if the data has been labelled with a variable that can be considered a target in the CSV. The image features are each treated like regular columns containing data.
+``pic2vec`` generates a flat CSV which is ready for supervised modeling, if the data has been labelled with a variable that
+can be used as a target. The images are transformed into a set of regular columns containing numeric data.
+Additionally, if unlabelled, it can be used for unsupervised learning (such as anomaly detection).
 
 
 ### Running tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ scipy>=1.1,<2
 tensorflow>=1.2.0,<2
 keras>=2.0.8,<2.1.5
 pandas>=0.20.2,<1
-Pillow>=4.1.1,<5
+Pillow>=5.4.1,<6
 trafaret>=0.10.2,<0.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.100.0
+current_version = 0.100.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     'tensorflow>=1.2.0,<2',
     'keras>=2.0.8,<2.1.5',
     'pandas>=0.20.2,<1',
-    'Pillow>=4.1.1,<5',
+    'Pillow>=5.4.1,<6',
     'trafaret>=0.10.2,<0.11'
 ]
 
@@ -57,6 +57,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     test_suite='tests',
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ test_requirements = [
 
 setup(
     name='pic2vec',
-    version='0.100.0',
+    version='0.100.1',
     description='Featurize images using a decapitated, pre-trained deep learning network',
     long_description=readme + '\n\n' + history,
     author='Jett Oristaglio',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py27, py34, py35, py36, py37, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
     3.4: py34
-    3.3: py33
     2.7: py27
 
 [testenv:flake8]


### PR DESCRIPTION
Pillow 3 does not support Python 3.7. Updating to Pillow 5.4.1 maintains backwards compatibility, and allows support for Python 3.7.